### PR TITLE
assign required value to attribute before event emitted.

### DIFF
--- a/src/UnityWebgl.js
+++ b/src/UnityWebgl.js
@@ -168,15 +168,18 @@ export default class UnityWebgl extends EventSystem {
             config,
             (val) => ctx._setProgression(val)
           ).then(unity => {
-            ctx.emit('created')
-            ctx.unityInstance = unity
+            ctx.unityInstance = unity 
+            ctx.emit('created',unityInstance)
+            
           }).catch(err => {
-            ctx.emit('error', err)
             ctx.unityInstance = null
+            ctx.emit('error', err)
+            
           })
         } catch (err) {
-          ctx.emit('error', err)
           ctx.unityInstance = null
+          ctx.emit('error', err)
+          
         }
       },
       reject(err) {


### PR DESCRIPTION
When I want to access unityInstace attribute in UnityWebGL instance right in created event,I found the attribute is null. I need to use setTimeout to wait 1ms to unityInstace, which doesn't make sense. So I suggest this update.